### PR TITLE
Removed case of isInstanceOf because it is slow

### DIFF
--- a/models/Grammars/BaseGrammar.cfc
+++ b/models/Grammars/BaseGrammar.cfc
@@ -879,8 +879,9 @@ component displayname="Grammar" accessors="true" {
         if ( utils.isExpression( column ) ) {
             return column.getSql();
         }
-
-        if ( isInstanceOf( column, "qb.models.Schema.TableIndex" ) ) {
+        
+        //using structKeyExists instead of isInstanceOf( column, "qb.models.Schema.TableIndex" ) because its slow
+        if ( structKeyExists( column, "setColumns" ) ) {
             throw(
                 type = "InvalidColumn",
                 message = "Recieved a TableIndex instead of a Column when trying to create a Column.",


### PR DESCRIPTION
Working towards resolving https://ortussolutions.atlassian.net/browse/QB-20

Let me know if you are good with this method of fixing it and I can also fix another case for you.

Also note, I'm using `structKeyExists` here instead of `obj.keyExists()` because the member function doesn't work on a component instance - it triggers onMissingMethod